### PR TITLE
Improve CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,30 +31,21 @@ jobs:
             . venv/bin/activate
             make build
 
-  deploy-job:
+      - persist_to_workspace:
+          root: ryr-docs/
+          paths:
+            - target/application.jar
+            - site/*
+
+  publish:
     docker:
       - image: circleci/python:3.6.1
 
     working_directory: ~/repo
 
     steps:
-      - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - deps-{{ checksum "requirements/local.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - deps-
-
-      - run:
-          name: Install dependencies.
-          command: make venv
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: deps-{{ checksum "requirements/local.txt" }}
+      - attach_workspace:
+        at: ryr-docs/
 
       - add_ssh_keys:
           fingerprints:
@@ -71,7 +62,7 @@ workflows:
   build-deploy:
     jobs:
       - build
-      - deploy-job:
+      - publish:
           requires:
             - build
           filters:


### PR DESCRIPTION
Reuses the workspace throughout the duration of the workflow. This
allows us to reuse the build site instead of building it twice for no
specific reason.