### PR TITLE
Leverage Makefile in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,14 +28,13 @@ jobs:
       - run:
           name: Build the site.
           command: |
-            . venv/bin/activate
             make build
 
       - persist_to_workspace:
-          root: ryr-docs/
+          root: ./
           paths:
-            - target/application.jar
-            - site/*
+            - venv
+            - ryr-docs/site/*
 
   publish:
     docker:
@@ -54,8 +53,7 @@ jobs:
       - run:
           name: Deploy the site.
           command: |
-            . venv/bin/activate
-            cd ryr-docs && mkdocs gh-deploy -v --clean
+            make publish
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ help: # Display help
 		}' $(MAKEFILE_LIST) | sort
 
 build: venv ## Build the documentatrion site
-	cd ryr-docs && mkdocs build -v -s
+	. venv/bin/activate && cd ryr-docs && mkdocs build -v -s
 
 setup: venv ## Setup the full environment (default)
+
+publish: venv ## Publish the site to github pages
+	. venv/bin/activate && cd ryr-docs && mkdocs gh-deploy -v --clean
 
 venv: venv/bin/activate ## Setup local venv
 


### PR DESCRIPTION
Implements the `publish` target and fix the build one. These targets are
then used by CircleCI to build and publish the site.

CircleCI now also stores the `venv` as part of the workspace.